### PR TITLE
Add new button jumps

### DIFF
--- a/AdminOnSteroids.js
+++ b/AdminOnSteroids.js
@@ -1316,7 +1316,7 @@ $(document).ready(function () {
 
                     var modulesArray = [],
                         mainTbody = '#modules_form .AdminDataTable:eq(0) tbody',
-                        addNewBtn = '<button type="button" id="add_new_button" class="ui-button ui-widget ui-corner-all ui-priority-secondary"><span class="ui-button-text"><i class="fa fa-plus-circle"></i> ' + AOSsettings.loc['add_new'] + '</span></button>',
+                        addNewBtn = '<button type="button" id="add_new_button" class="ui-button ui-widget ui-corner-all ui-priority-secondary ui-state-default"><span class="ui-button-text"><i class="fa fa-plus-circle"></i> ' + AOSsettings.loc['add_new'] + '</span></button>',
                         addNewBlock = $('#tab_new_modules'),
                         addNewBlockInput = addNewBlock.find('input:eq(0)'),
                         mainBlock = $('#tab_site_modules');


### PR DESCRIPTION
Minor detail....

When visiting admin/modules the add new button jumps slightly when it is first hovered using the default admin theme.

This is when "Do not distribute modules into tabs" is enabled.

![modules processwire pw3 dev 2016-10-31 14-47-42](https://cloud.githubusercontent.com/assets/40570/19869232/6e61165a-9f79-11e6-9812-cd7a026a6efe.jpg)