### PR TITLE
check if $field is an object

### DIFF
--- a/AdminOnSteroids.module
+++ b/AdminOnSteroids.module
@@ -1700,6 +1700,10 @@ class AdminOnSteroids extends WireData implements Module, ConfigurableModule {
         }
 
         if ($field = $this->fields->get($inputfield->name)) {
+        
+            if (!is_object($field)) {
+                return;
+            }
 
             // add class to wrapper to be able to use :hover even if label is unavailable (eg. checkbox field)
             $inputfield->wrapAttr('class', $inputfield->wrapAttr('class') . ' aos_hasTooltip');


### PR DESCRIPTION
I got the following error notice, when i tried to setup a menu with the MenuBuilder module.

> Notice: Trying to get property of non-object in /Users/user/server/site/assets/cache/FileCompiler/site/modules/AdminOnSteroids/AdminOnSteroids.module on line 1708

In this case $field wasn't a processwire object.

Seems like the last (merged) pull request for this issue, was lost.