### PR TITLE
Fix for InputfieldCheckbox not displaying correctly

### DIFF
--- a/src/aos.scss
+++ b/src/aos.scss
@@ -1357,7 +1357,7 @@ html.hideAddNewDropdown body.id-3 {
   }
 }
 
-.InputfieldCheckbox.aos_hasTooltip{
+.InputfieldCheckbox{
   position:relative;
 }
 


### PR DESCRIPTION
Found another page where checkboxes weren't displaying correctly.  This change allows InputfieldCheckbox to display correctly even if they don't have tooltips.  Ex. checkboxes on module settings pages.