### PR TITLE
Fix configurable modules cog wheel icon alignment on admin/module

### DIFF
--- a/src/aos.scss
+++ b/src/aos.scss
@@ -1821,6 +1821,7 @@ html.moduleCompact {
             font-family: FontAwesome, sans-serif;
             position: absolute;
             font-size: 28px;
+            line-height: .9em;
             color: rgba(#364D68, 0.25);
             margin-top: 0;
             margin-left: 0;


### PR DESCRIPTION
The vertical alignment of the cog icons are too low on the admin/module page.  This should fix that.

Tested in all three admin themes.
![cogs](https://user-images.githubusercontent.com/40570/33999473-2c34d13a-e0b0-11e7-8813-d01fd1ec0822.jpg)
